### PR TITLE
#360-feat: Introduce Report Category to Reports Table

### DIFF
--- a/Beelina.APP/src/app/_enum/report-category.enum.ts
+++ b/Beelina.APP/src/app/_enum/report-category.enum.ts
@@ -1,0 +1,19 @@
+export enum ReportCategoryEnum {
+  OrderTransactions = "ORDER_TRANSACTIONS",
+  Products = "PRODUCTS",
+  Sales = "SALES"
+}
+
+
+export function getReportCategoryNumeric(category: ReportCategoryEnum): number {
+  switch (category) {
+    case ReportCategoryEnum.OrderTransactions:
+      return 1;
+    case ReportCategoryEnum.Products:
+      return 2;
+    case ReportCategoryEnum.Sales:
+      return 3;
+    default:
+      return 0;
+  }
+}

--- a/Beelina.APP/src/app/_interfaces/report-group.interface.ts
+++ b/Beelina.APP/src/app/_interfaces/report-group.interface.ts
@@ -1,0 +1,9 @@
+import { Report } from '../_models/report';
+import { ReportCategoryEnum } from '../_enum/report-category.enum';
+
+export interface ReportGroup {
+  category: ReportCategoryEnum;
+  categoryLabelKey: string; // i18n translation key for category name
+  reports: Report[];
+  isCollapsed: boolean;
+}

--- a/Beelina.APP/src/app/_models/report.ts
+++ b/Beelina.APP/src/app/_models/report.ts
@@ -1,6 +1,7 @@
 import { Entity } from './entity.model';
 
 import { ReportControlsRelation } from './report-control-relation';
+import { ReportCategoryEnum } from '../_enum/report-category.enum';
 
 export class Report extends Entity {
   name: string;
@@ -10,6 +11,7 @@ export class Report extends Entity {
   reportClass: string;
   custom: boolean;
   storedProcedureName: string;
+  category: ReportCategoryEnum;
   reportControlsRelations: ReportControlsRelation[];
 
   constructor() {

--- a/Beelina.APP/src/app/_services/reports.service.ts
+++ b/Beelina.APP/src/app/_services/reports.service.ts
@@ -20,6 +20,7 @@ const GET_ALL_REPORTS = gql`
       nameTextIdentifier
       descriptionTextIdentifier
       moduleId
+      category
     }
   }
 `;
@@ -125,6 +126,7 @@ export class ReportsService {
             report.descriptionTextIdentifier = rp.descriptionTextIdentifier;
             report.reportClass = rp.reportClass;
             report.custom = rp.custom;
+            report.category = rp.category;
 
             // rp.reportControlsRelations.forEach((rr: ReportControlsRelation) => {
             //   const reportControlsRelation = new ReportControlsRelation();

--- a/Beelina.APP/src/app/reports/reports.component.html
+++ b/Beelina.APP/src/app/reports/reports.component.html
@@ -13,25 +13,53 @@
     <app-list-container [templateType]="emptyEntityTemplateEnum.REPORTS" [count]="reports?.length">
       <div class="list-container">
 
-        @for (item of reports; track $index) {
-        <div>
-          <div class="list-container__item-section" matRipple (click)="goToReportInformation(item.id)">
-            <div class="list-container__icon-section list-container__icon-section--right-space">
-              <div class="list-container__icon-section--icon-container">
-                <mat-icon>bar_chart</mat-icon>
-              </div>
+        @for (group of reportGroups; track $index) {
+          <div class="report-category-section">
+            <!-- Category Header -->
+            <div class="category-header"
+                 (click)="toggleCategoryCollapse(group)"
+                 matRipple
+                 role="button"
+                 [attr.aria-expanded]="!group.isCollapsed"
+                 [attr.aria-controls]="'reports-' + $index"
+                 tabindex="0"
+                 (keydown.enter)="onKeyboardToggle($event, group)"
+                 (keydown.space)="onKeyboardToggle($event, group)">
+              <mat-icon class="collapse-icon" [class.rotated]="group.isCollapsed">
+                expand_more
+              </mat-icon>
+              <h3 class="category-title">{{ group.categoryLabelKey | translate }}</h3>
+              <div class="category-divider"></div>
+              <span class="reports-count">({{ group.reports.length }})</span>
             </div>
-            <div class="list-container__details-section">
-              <label style="margin-bottom: 8px" class="main-label">{{
-                item.name
-                }}</label>
-              <label>{{ item.description }}</label>
-            </div>
-            <div class="list-container__options-section">
-              <mat-icon class="option">keyboard_arrow_right</mat-icon>
+
+            <!-- Reports in this category -->
+            <div class="reports-list"
+                 [@slideInOut]="group.isCollapsed ? 'out' : 'in'"
+                 [id]="'reports-' + $index"
+                 [attr.aria-hidden]="group.isCollapsed">
+              @for (item of group.reports; track $index) {
+                <div>
+                  <div class="list-container__item-section" matRipple (click)="goToReportInformation(item.id)">
+                    <div class="list-container__icon-section list-container__icon-section--right-space">
+                      <div class="list-container__icon-section--icon-container">
+                        <mat-icon>bar_chart</mat-icon>
+                      </div>
+                    </div>
+                    <div class="list-container__details-section">
+                      <label style="margin-bottom: 8px" class="main-label">{{
+                        item.name
+                        }}</label>
+                      <label>{{ item.description }}</label>
+                    </div>
+                    <div class="list-container__options-section">
+                      <mat-icon class="option">keyboard_arrow_right</mat-icon>
+                    </div>
+                  </div>
+                </div>
+              }
             </div>
           </div>
-        </div>
         }
 
       </div>

--- a/Beelina.APP/src/app/reports/reports.component.scss
+++ b/Beelina.APP/src/app/reports/reports.component.scss
@@ -1,0 +1,101 @@
+@import "../../app-variables";
+
+.report-category-section {
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.category-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-top: 16px;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: $border-radius-sm;
+  transition: $transition-normal;
+  user-select: none;
+  min-height: 48px; // Ensure consistent height
+
+  &:hover {
+    background-color: rgba($primary, $opacity-light);
+    transform: translateY(-1px);
+    box-shadow: $shadow-sm;
+  }
+
+  &:focus {
+    outline: 2px solid $primary;
+    outline-offset: 2px;
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  .collapse-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: $spacing-sm;
+    transition: transform $transition-normal;
+    color: $primary;
+    font-size: 1.25em;
+    width: 24px; // Fixed width for consistent alignment
+    height: 24px; // Fixed height for consistent alignment
+    flex-shrink: 0; // Prevent shrinking
+
+    &.rotated {
+      transform: rotate(-90deg);
+    }
+  }
+
+  .category-title {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    font-size: 1.0625em; // 17px equivalent, matching page titles
+    font-weight: bold; // Following app pattern for section titles
+    color: $primary;
+    white-space: nowrap;
+    margin-right: $spacing-md;
+    font-family: Roboto, "Helvetica Neue", sans-serif; // Explicit font family
+    line-height: 1.2; // Consistent line height
+    flex-shrink: 0; // Prevent shrinking
+  }
+
+  .category-divider {
+    flex: 1;
+    height: 1px;
+    background-color: $border-light;
+    margin-right: $spacing-sm;
+    align-self: center; // Ensure divider is centered
+  }
+
+  .reports-count {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $text-secondary;
+    font-size: 0.75em; // 12px equivalent, matching description text
+    font-weight: 500;
+    background-color: rgba($gray-500, $opacity-light);
+    padding: 4px $spacing-sm;
+    border-radius: $border-radius-md;
+    min-width: 24px; // Minimum width for small numbers
+    height: 24px; // Fixed height for consistent alignment
+    flex-shrink: 0; // Prevent shrinking
+    line-height: 1; // Tight line height for badges
+  }
+}
+
+.reports-list {
+  overflow: hidden;
+}
+
+// Override margin for list items within categories
+.report-category-section .list-container__item-section {
+  margin-bottom: $spacing-sm;
+}

--- a/Beelina.APP/src/assets/i18n/en.json
+++ b/Beelina.APP/src/assets/i18n/en.json
@@ -1117,6 +1117,12 @@
       "PURCHASE_ORDER_REPORT_DESC": "This report can generate detailed purchase order information including supplier details, reference numbers, and warehouse stock entries for a given date range.",
       "SUPPLIER_PRODUCT_TRANSACTIONS_REPORT_NAME": "Supplier Product Transactions Report",
       "SUPPLIER_PRODUCT_TRANSACTIONS_REPORT_DESC": "This report can generate the product transactions for a specific supplier, allowing for detailed analysis of sales and inventory."
+    },
+    "CATEGORIES": {
+      "ORDER_TRANSACTIONS": "Order Transactions",
+      "PRODUCTS": "Products",
+      "SALES": "Sales",
+      "OTHER": "Other"
     }
   },
   "REPORT_DETAILS_PAGE": {

--- a/Beelina.LIB/Enums/ReportCategoryEnum.cs
+++ b/Beelina.LIB/Enums/ReportCategoryEnum.cs
@@ -1,0 +1,9 @@
+﻿namespace Beelina.LIB.Enums
+{
+    public enum ReportCategoryEnum
+    {
+        OrderTransactions = 1,
+        Products = 2,
+        Sales = 3
+    }
+}

--- a/Beelina.LIB/Migrations/BeelinaData/20250827132915_IntroduceReportCategoryOnReportsTable.Designer.cs
+++ b/Beelina.LIB/Migrations/BeelinaData/20250827132915_IntroduceReportCategoryOnReportsTable.Designer.cs
@@ -4,6 +4,7 @@ using Beelina.LIB.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Beelina.LIB.Migrations.BeelinaData
 {
     [DbContext(typeof(BeelinaDataContext))]
-    partial class BeelinaDataContextModelSnapshot : ModelSnapshot
+    [Migration("20250827132915_IntroduceReportCategoryOnReportsTable")]
+    partial class IntroduceReportCategoryOnReportsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Beelina.LIB/Migrations/BeelinaData/20250827132915_IntroduceReportCategoryOnReportsTable.cs
+++ b/Beelina.LIB/Migrations/BeelinaData/20250827132915_IntroduceReportCategoryOnReportsTable.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Beelina.LIB.Migrations.BeelinaData
+{
+    /// <inheritdoc />
+    public partial class IntroduceReportCategoryOnReportsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Category",
+                table: "Reports",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Category",
+                table: "Reports");
+        }
+    }
+}

--- a/Beelina.LIB/Migrations/BeelinaData/20250827133841_AssignReportCategoriesToExistingReports.Designer.cs
+++ b/Beelina.LIB/Migrations/BeelinaData/20250827133841_AssignReportCategoriesToExistingReports.Designer.cs
@@ -4,6 +4,7 @@ using Beelina.LIB.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Beelina.LIB.Migrations.BeelinaData
 {
     [DbContext(typeof(BeelinaDataContext))]
-    partial class BeelinaDataContextModelSnapshot : ModelSnapshot
+    [Migration("20250827133841_AssignReportCategoriesToExistingReports")]
+    partial class AssignReportCategoriesToExistingReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Beelina.LIB/Migrations/BeelinaData/20250827133841_AssignReportCategoriesToExistingReports.cs
+++ b/Beelina.LIB/Migrations/BeelinaData/20250827133841_AssignReportCategoriesToExistingReports.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Beelina.LIB.Migrations.BeelinaData
+{
+    /// <inheritdoc />
+    public partial class AssignReportCategoriesToExistingReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Order Transactions Category (ReportCategoryEnum.OrderTransactions = 1)
+            migrationBuilder.Sql(@"
+                UPDATE Reports 
+                SET Category = 1 
+                WHERE ReportClass IN (
+                    'CustomerDetailedTransactionsReport',
+                    'DailyDetailedTransactionsReport',
+                    'DailySummarizeTransactionsReport',
+                    'SupplierProductTransactionsReport'
+                )");
+
+            // Products Category (ReportCategoryEnum.Products = 2)
+            migrationBuilder.Sql(@"
+                UPDATE Reports 
+                SET Category = 2 
+                WHERE ReportClass IN (
+                    'EndingInventoryPerProductReportAdmin',
+                    'EndingInventoryPerProductReportAgent',
+                    'ProductWithdrawalReport',
+                    'ProductWithdrawalReport2',
+                    'PurchaseOrderReport'
+                )");
+
+            // Sales Category (ReportCategoryEnum.Sales = 3)
+            migrationBuilder.Sql(@"
+                UPDATE Reports 
+                SET Category = 3 
+                WHERE ReportClass IN (
+                    'CustomerCollectionSummaryReport',
+                    'SalesAgentCollectionSummaryReport',
+                    'SalesPerCustomerReport'
+                )");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Reset all categories to default value (0)
+            migrationBuilder.Sql("UPDATE Reports SET Category = 0");
+        }
+    }
+}

--- a/Beelina.LIB/Models/Report.cs
+++ b/Beelina.LIB/Models/Report.cs
@@ -12,6 +12,7 @@ namespace Beelina.LIB.Models
         public bool Lock { get; set; }
         public string StoredProcedureName { get; set; }
         public ModulesEnum ModuleId { get; set; }
+        public ReportCategoryEnum Category { get; set; }
         public PermissionLevelEnum UserMinimumModulePermission { get; set; }
         public PermissionLevelEnum UserMaximumModulePermission { get; set; }
         public string OnlyAvailableOnBusinessModel { get; set; }


### PR DESCRIPTION
- Added a new column 'Category' to the 'Reports' table to categorize reports.
- Created a migration to assign existing reports to appropriate categories based on their ReportClass.
- Updated the model snapshot to reflect the new 'Category' property in the Report model.
- Modified the Report model to include the 'Category' property of type ReportCategoryEnum.